### PR TITLE
NETStandard

### DIFF
--- a/src/OwinRequestScopeContext.Tests/OwinRequestScopeContext.Tests.csproj
+++ b/src/OwinRequestScopeContext.Tests/OwinRequestScopeContext.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +13,8 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -75,4 +78,10 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props'))" />
+  </Target>
 </Project>

--- a/src/OwinRequestScopeContext.Tests/packages.config
+++ b/src/OwinRequestScopeContext.Tests/packages.config
@@ -3,5 +3,6 @@
   <package id="FakeItEasy" version="4.0.0" targetFramework="net462" />
   <package id="FluentAssertions" version="4.19.3" targetFramework="net462" />
   <package id="NUnit" version="3.7.1" targetFramework="net462" />
+  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net462" />
   <package id="Owin" version="1.0" targetFramework="net462" />
 </packages>

--- a/src/OwinRequestScopeContext/CallContext.cs
+++ b/src/OwinRequestScopeContext/CallContext.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Concurrent;
+using System.Threading;
+
+namespace DavidLievrouw.OwinRequestScopeContext
+{
+    /// <summary>
+    /// Provides a way to set contextual data that flows with the call and 
+    /// async context of a test or invocation.
+    /// </summary>
+    public static class CallContext
+    {
+        static ConcurrentDictionary<string, AsyncLocal<object>> state = new ConcurrentDictionary<string, AsyncLocal<object>>();
+
+        /// <summary>
+        /// Stores a given object and associates it with the specified name.
+        /// </summary>
+        /// <param name="name">The name with which to associate the new item in the call context.</param>
+        /// <param name="data">The object to store in the call context.</param>
+        public static void SetData(string name, object data) =>
+            state.GetOrAdd(name, _ => new AsyncLocal<object>()).Value = data;
+
+        /// <summary>
+        /// Retrieves an object with the specified name from the <see cref="CallContext"/>.
+        /// </summary>
+        /// <param name="name">The name of the item in the call context.</param>
+        /// <returns>The object in the call context associated with the specified name, or <see langword="null"/> if not found.</returns>
+        public static object GetData(string name) =>
+            state.TryGetValue(name, out AsyncLocal<object> data) ? data.Value : null;
+
+
+       /// <summary>
+       /// Removes an object from call context with the specified name.
+       /// </summary>
+       /// <param name="name"></param>
+       /// <returns></returns>
+        public static bool FreeNamedDataSlot(string name) =>
+            state.TryRemove(name, out AsyncLocal<object> data) ? true : false;
+    }
+}

--- a/src/OwinRequestScopeContext/OwinRequestScopeContext.cs
+++ b/src/OwinRequestScopeContext/OwinRequestScopeContext.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Runtime.Remoting.Messaging;
 
-namespace DavidLievrouw.OwinRequestScopeContext {
-  public class OwinRequestScopeContext : IOwinRequestScopeContext {
+namespace DavidLievrouw.OwinRequestScopeContext
+{
+    public class OwinRequestScopeContext : IOwinRequestScopeContext {
     const string CallContextKey = "dl.owin.rscopectx";
 
     internal OwinRequestScopeContext(
@@ -21,8 +21,8 @@ namespace DavidLievrouw.OwinRequestScopeContext {
     }
 
     public static IOwinRequestScopeContext Current {
-      get => (IOwinRequestScopeContext) CallContext.LogicalGetData(CallContextKey);
-      internal set => CallContext.LogicalSetData(CallContextKey, value);
+      get => (IOwinRequestScopeContext) CallContext.GetData(CallContextKey);
+      internal set => CallContext.SetData(CallContextKey, value);
     }
 
     internal OwinRequestScopeContextOptions Options { get; }

--- a/src/OwinRequestScopeContext/OwinRequestScopeContext.csproj
+++ b/src/OwinRequestScopeContext/OwinRequestScopeContext.csproj
@@ -1,68 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{8D3859AC-EBCF-4346-B437-C099B4D2B03F}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>DavidLievrouw.OwinRequestScopeContext</RootNamespace>
     <AssemblyName>DavidLievrouw.OwinRequestScopeContext</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile />
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <NoWarn>IDE0016</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
-      <HintPath>..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
+    <PackageReference Include="Owin" Version="1.0.0" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Include="..\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="..\InternalsVisibleTo.cs">
       <Link>Properties\InternalsVisibleTo.cs</Link>
-    </Compile>
-    <Compile Include="AppBuilderExtensions.cs" />
-    <Compile Include="Extensions.ForEach.cs" />
-    <Compile Include="IInternalOwinRequestScopeContextItems.cs" />
-    <Compile Include="IOwinRequestScopeContext.cs" />
-    <Compile Include="IOwinRequestScopeContextItems.cs" />
-    <Compile Include="OwinRequestScopeContext.cs" />
-    <Compile Include="OwinRequestScopeContextItems.cs" />
-    <Compile Include="OwinRequestScopeContextMiddleware.cs" />
-    <Compile Include="OwinRequestScopeContextOptions.cs" />
+    </Compile>    
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+
 </Project>

--- a/src/OwinRequestScopeContext/packages.config
+++ b/src/OwinRequestScopeContext/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Owin" version="1.0" targetFramework="net462" />
-</packages>


### PR DESCRIPTION
This PR closes #2 
- Updated csproj for the main library to use newer SDK format, and target `netstandard2.0`.
- Removed packages.config from that project.
- Had to use a replacement to mimic `CallContext` based on `AsyncLocal` - I found that here with tests: https://www.cazzulino.com/callcontext-netstandard-netcore.html
- I had to add the NuGet adapator nuget package to the tests project before I could run them directly from visual studio test explorer - all tests pass.